### PR TITLE
PR to fix w016 play

### DIFF
--- a/roles/tasks/w016.yml
+++ b/roles/tasks/w016.yml
@@ -7,6 +7,6 @@
     - name: Install python and go
       ansible.builtin.package:
         name: "{{ item }}"
-        with_items:
-          - python
-          - go
+      with_items:
+        - python
+        - go

--- a/roles/tasks/w019.yml
+++ b/roles/tasks/w019.yml
@@ -2,6 +2,7 @@
 ---
 - name: Example playbook
   hosts: all
+
   tasks:
     - name: Enable LLDP service
       cisco.ios.ios_lldp:

--- a/roles/tasks/w019.yml
+++ b/roles/tasks/w019.yml
@@ -1,8 +1,9 @@
 # Rule W019 - Replace deprecated module
 ---
 - name: Example playbook
+  gather_facts: false
   hosts: all
-
+  become: false
   tasks:
     - name: Enable LLDP service
       cisco.ios.ios_lldp:

--- a/roles/tasks/w019.yml
+++ b/roles/tasks/w019.yml
@@ -1,9 +1,7 @@
 # Rule W019 - Replace deprecated module
 ---
 - name: Example playbook
-  gather_facts: false
   hosts: all
-  become: false
   tasks:
     - name: Enable LLDP service
       cisco.ios.ios_lldp:


### PR DESCRIPTION
After the update, and fixing the indentation of `with_items` if we run the ARI scan, it will result in following update:

```
- name: Install python and go
  ansible.builtin.package:
    name: "{{ item }}"
  loop:
    - python
    - go
```
This is expected for updating the `with_items` to loop instead, this may not actually test the `W016` rule though. So, for testing W016 rule in particular use the `yum` module instead of `package` module. As Ansible package module doesn't accept parameter in list format, compared to `yum` module which does accepts name parameter as list format. 

I've created a [PR](https://github.com/ansible/ari-metrics-for-wisdom/pull/79) to update the W016 rule to accept `ansible.builtin.package` explicitly. And, once the PR gets merged the test playbook should be working as expected.